### PR TITLE
Update README clone instructions with correct repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ An interactive web application that uses hand tracking to manipulate and join da
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/yourusername/handtracking.git
-cd handtracking
+git clone https://github.com/dshukertjr/iron-man-table.git
+cd iron-man-table
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
This PR updates the README.md file to reflect the correct repository URL and directory name in the "Clone the repository" section.

Changes made:

Replaced the outdated clone URL https://github.com/yourusername/handtracking.git with the correct one: https://github.com/dshukertjr/iron-man-table.git

Updated the corresponding directory name from cd handtracking to cd iron-man-table

This fix ensures accurate instructions for users intending to clone and navigate the project repository.